### PR TITLE
Move Plesk check to main()

### DIFF
--- a/pleskbuddy.py
+++ b/pleskbuddy.py
@@ -108,7 +108,7 @@ def php_handler():
 def main():
     # Check if Plesk is installed
     try:
-        _ =open('/usr/local/psa/version', 'r')
+        _ = open('/usr/local/psa/version', 'r')
     except IOError as ex:
         sys.exit('It doesn\'t look like Plesk is installed!')
     

--- a/pleskbuddy.py
+++ b/pleskbuddy.py
@@ -32,13 +32,6 @@ def options():
     return psa_parser
 
 
-# Check if Plesk is installed
-try:
-    CHECK_PSA = open('/usr/local/psa/version', 'r')
-except IOError as ex:
-    sys.exit('It doesn\'t look like Plesk is installed!')
-
-
 class Color(object):
     RED = '\033[31m\033[1m'
     GREEN = '\033[32m\033[1m'
@@ -113,6 +106,12 @@ def php_handler():
 
 
 def main():
+    # Check if Plesk is installed
+    try:
+        _ =open('/usr/local/psa/version', 'r')
+    except IOError as ex:
+        sys.exit('It doesn\'t look like Plesk is installed!')
+    
     if PSA_ARGS.show_version:
         show_version()
     elif PSA_ARGS.subscription_list:


### PR DESCRIPTION
The Plesk check being in main allow the `--help` command to work even without Plesk being installed

eg.
```
usage: pb.py [-h] [-v] [--sub-list] [--info] [--domain-list]
             [--list-components] [--install-component COMPONENT_INSTALL]
             [--php-handler]

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         Shows version information
  --sub-list            Shows a list of subscriptions
  --info                Shows a list of subscriptions
  --domain-list         Shows a list of domains with their IP addresses
  --list-components     Creates a list of available components
  --install-component COMPONENT_INSTALL
                        Allows installation of available component
  --php-handler         Displays a list of domains with their respective PHP
                        handler
```