### PR TITLE
Use http for icanhazip for EL6

### DIFF
--- a/pleskbuddy.py
+++ b/pleskbuddy.py
@@ -17,7 +17,7 @@ except ImportError:
     from urllib2 import urlopen
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 
 def options():
@@ -117,7 +117,7 @@ def info():
         .strip()
         .decode("utf-8")
     )
-    public_ip = urlopen("https://ipv4.icanhazip.com").read().strip().decode("utf-8")
+    public_ip = urlopen("http://ipv4.icanhazip.com").read().strip().decode("utf-8")
     psa_info = (
         Color.MAGENTA
         + "==== Plesk Information ====\n"


### PR DESCRIPTION
Moves icanhazip to http to work around the certificate failure on EL6 devices;

~~~
Traceback (most recent call last):
  File "pleskbuddy.py", line 204, in <module>
    main()
  File "pleskbuddy.py", line 200, in main
    info()
  File "pleskbuddy.py", line 120, in info
    public_ip = urlopen("https://ipv4.icanhazip.com").read().strip().decode("utf-8")
  File "/usr/lib64/python2.6/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib64/python2.6/urllib2.py", line 391, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.6/urllib2.py", line 409, in _open
    '_open', req)
  File "/usr/lib64/python2.6/urllib2.py", line 369, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.6/urllib2.py", line 1198, in https_open
    return self.do_open(httplib.HTTPSConnection, req)
  File "/usr/lib64/python2.6/urllib2.py", line 1165, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [Errno 1] _ssl.c:492: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>
~~~
